### PR TITLE
Only cache the documentation builds on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -111,12 +111,14 @@ jobs:
         run: python -m pip install dist/*.whl
 
       - name: Cache the v1 datasets
+        if: github.event_name == 'pull_request' 
         uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/cache/ensaio/v1
           key: ensaio-data-v1-${{ hashFiles('ensaio/v1.py') }}
 
       - name: Cache the v1 sphinx-gallery runs
+        if: github.event_name == 'pull_request' 
         uses: actions/cache@v2
         with:
           path: doc/gallery/v1


### PR DESCRIPTION
Caching the built sphinx-gallery output can cause the backreferences in
API docs to not appear. Best to only cache in PRs to make the builds
quicker and then rebuild from scratch on main and releases.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
