### PR TITLE
Add the Sierra Negra volcano topography data

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -17,4 +17,5 @@ List of functions and classes (API)
     ensaio.fetch_earth_gravity
     ensaio.fetch_earth_topography
     ensaio.fetch_osborne_magnetic
+    ensaio.fetch_sierra_negra_topography
     ensaio.fetch_southern_africa_gravity

--- a/doc/gallery_src/sierra-negra-topography.py
+++ b/doc/gallery_src/sierra-negra-topography.py
@@ -5,16 +5,17 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 """
-Topography of the Trail Islands in British Columbia, Canada
------------------------------------------------------------
+Topography of the 2018 lava flows of the Sierra Negra volcano, Ecuador
+----------------------------------------------------------------------
 
-This is a lidar point cloud (ground reflections only) sliced to the small
-`Trail Islands <https://apps.gov.bc.ca/pub/bcgnws/names/21973.html>`__
-to the North of Vancouver. The islands have some nice looking topography and
-their isolated nature creates problems for some interpolation methods.
+This is a structure-from-motion point cloud of the 2018 lava flows of the
+Sierra Negra volcano, located on the Galápagos islands, Ecuador. The survey
+covers a small region at the flank of the volcano and shows different
+structures and terrain roughness on the lava flows.
 
-**Original source:** `LidarBC
-<https://www2.gov.bc.ca/gov/content/data/geographic-data-services/lidarbc>`__
+**Original source:** `Carr, B. (2020). Sierra Negra Volcano (TIR Flight 3):
+Galápagos, Ecuador, October 22 2018. Distributed by OpenTopography.
+<https://doi.org/10.5069/G957196P>`__
 
 """
 import pandas as pd
@@ -24,7 +25,7 @@ import ensaio
 
 ###############################################################################
 # Download and cache the data and return the path to it on disk
-fname = ensaio.fetch_british_columbia_lidar(version=1)
+fname = ensaio.fetch_sierra_negra_topography(version=1)
 print(fname)
 
 ###############################################################################
@@ -47,7 +48,7 @@ fig.basemap(
 )
 pygmt.makecpt(cmap="viridis", series=[data.elevation_m.min(), data.elevation_m.max()])
 fig.plot(
-    x=data.longitude, y=data.latitude, color=data.elevation_m, cmap=True, style="c0.05c"
+    x=data.longitude, y=data.latitude, color=data.elevation_m, cmap=True, style="c0.01c"
 )
 fig.colorbar(frame='af+l"elevation [m]"')
 fig.show()

--- a/ensaio/__init__.py
+++ b/ensaio/__init__.py
@@ -14,6 +14,7 @@ from ._fetchers import (
     fetch_earth_gravity,
     fetch_earth_topography,
     fetch_osborne_magnetic,
+    fetch_sierra_negra_topography,
     fetch_southern_africa_gravity,
     locate,
 )

--- a/ensaio/_fetchers.py
+++ b/ensaio/_fetchers.py
@@ -69,6 +69,13 @@ REGISTRY = {
             "url": "https://github.com/fatiando-data/osborne-magnetic/releases/download/v1",
         },
     },
+    "sierra-negra-topography.csv.xz": {
+        "v1": {
+            "hash": "md5:9f6f64d47d26773e37b154cf964724e3",
+            "doi": "doi:10.5281/zenodo.6139057",
+            "url": "https://github.com/fatiando-data/sierra-negra-topography/releases/download/v1",
+        },
+    },
     "southern-africa-gravity.csv.xz": {
         "v1": {
             "hash": "md5:1dee324a14e647855366d6eb01a1ef35",
@@ -279,7 +286,7 @@ def fetch_britain_magnetic(version):
 
 def fetch_british_columbia_lidar(version):
     """
-    Lidar point cloud data of the Trail Islands in BC, Canada
+    Topography (lidar point cloud) data of the Trail Islands in BC, Canada
 
     This is a lidar point cloud (ground reflections only) sliced to the small
     `Trail Islands <https://apps.gov.bc.ca/pub/bcgnws/names/21973.html>`__
@@ -554,6 +561,50 @@ def fetch_osborne_magnetic(version):
     """
     _check_versions(version, allowed={1}, name="Osborne mine magnetic")
     fname = "osborne-magnetic.csv.xz"
+    return Path(_repository(fname, version).fetch(fname))
+
+
+def fetch_sierra_negra_topography(version):
+    """
+    Topography of the 2018 lava flows of the Sierra Negra volcano, Ecuador
+
+    This is a structure-from-motion point cloud of the 2018 lava flows of the
+    Sierra Negra volcano, located on the Galápagos islands, Ecuador. The survey
+    is of a small region on the flank of the volcano. The horizontal datum is
+    WGS84 but the vertical datum for "elevation" is unspecified.
+
+    There are ~1,700,000 measurements in total with 3 columns available:
+    longitude, latitude (geodetic), elevation.
+
+    **Format:** CSV with xz (lzma) compression.
+
+    **Load with:** :func:`pandas.read_csv`
+
+    **Original source:** `Carr, B. (2020). Sierra Negra Volcano (TIR Flight 3):
+    Galápagos, Ecuador, October 22 2018. Distributed by OpenTopography.
+    <https://doi.org/10.5069/G957196P>`__
+
+    **Original license:** CC-BY
+
+    **Versions:**
+
+    * `1
+      <https://github.com/fatiando-data/sierra-negra-topography/releases/tag/v1>`_
+      (doi:`10.5281/zenodo.6139057 <https://doi.org/10.5281/zenodo.6139057>`__)
+
+    Parameters
+    ----------
+    version : int
+        The data version to fetch. See the available versions above.
+
+    Returns
+    -------
+    fname : :class:`pathlib.Path`
+        Path to the downloaded file on disk.
+
+    """
+    _check_versions(version, allowed={1}, name="Sierra Negra volcano topography")
+    fname = "sierra-negra-topography.csv.xz"
     return Path(_repository(fname, version).fetch(fname))
 
 


### PR DESCRIPTION
This is point cloud that includes some nice topographic features and
previous studies using terrain roughness to classify lava flows.
From https://github.com/fatiando-data/sierra-negra-topography
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
