### PR TITLE
Plot only the magnetic anomaly for Osborne mine

### DIFF
--- a/doc/gallery_src/osborne-magnetic.py
+++ b/doc/gallery_src/osborne-magnetic.py
@@ -36,56 +36,32 @@ data = pd.read_csv(fname)
 data
 
 ###############################################################################
-# Make two PyGMT maps with the data points colored by the total field magnetic
-# anomaly and also the observation height.
-
-region = [
-    data.longitude.min(),
-    data.longitude.max(),
-    data.latitude.min(),
-    data.latitude.max(),
-]
-
+# Make a PyGMT map with the data points colored by the total field magnetic
+# anomaly.
 fig = pygmt.Figure()
-with fig.subplot(
-    nrows=1,
-    ncols=2,
-    figsize=("30c", "20c"),
-    sharey="l",  # shared y-axis on the left side
-    frame="WSrt",
-):
-    with fig.set_panel(0):
-        fig.basemap(projection="M?", region=region, frame="af")
-        scale = 1500
-        pygmt.makecpt(cmap="polar+h", series=[-scale, scale], background=True)
-        fig.plot(
-            x=data.longitude,
-            y=data.latitude,
-            color=data.total_field_anomaly_nt,
-            style="c0.075c",
-            cmap=True,
-        )
-        fig.colorbar(
-            frame='af+l"total field magnetic anomaly [nT]"',
-            position="JBC+h+o0/1c+e",
-        )
-    with fig.set_panel(1):
-        fig.basemap(projection="M?", region=region, frame="af")
-        pygmt.makecpt(
-            cmap="viridis",
-            series=[data.height_orthometric_m.min(), data.height_orthometric_m.max()],
-        )
-        fig.plot(
-            x=data.longitude,
-            y=data.latitude,
-            color=data.height_orthometric_m,
-            style="c0.075c",
-            cmap=True,
-        )
-        fig.colorbar(
-            frame='af+l"observation height [m]"',
-            position="JBC+h+o0/1c",
-        )
+fig.basemap(
+    projection="M15c",
+    region=[
+        data.longitude.min(),
+        data.longitude.max(),
+        data.latitude.min(),
+        data.latitude.max(),
+    ],
+    frame="af",
+)
+scale = 1500
+pygmt.makecpt(cmap="polar+h", series=[-scale, scale], background=True)
+fig.plot(
+    x=data.longitude,
+    y=data.latitude,
+    color=data.total_field_anomaly_nt,
+    style="c0.075c",
+    cmap=True,
+)
+fig.colorbar(
+    frame='af+l"total field magnetic anomaly [nT]"',
+    position="JBC+h+o0/1c+e",
+)
 fig.show()
 
 ###############################################################################


### PR DESCRIPTION
Adding a plot of the flight height takes double the time and doesn't
include any more useful information. Plot only the anomaly data instead.
Also avoids the PyGMT subplot code that can be a bit confusing.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
