### PR TITLE
Add fetcher for the Bushveld gravity dataset

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -12,6 +12,7 @@ List of functions and classes (API)
     ensaio.fetch_alps_gps
     ensaio.fetch_britain_magnetic
     ensaio.fetch_british_columbia_lidar
+    ensaio.fetch_bushveld_gravity
     ensaio.fetch_caribbean_bathymetry
     ensaio.fetch_earth_geoid
     ensaio.fetch_earth_gravity

--- a/doc/gallery_src/bushveld-gravity.py
+++ b/doc/gallery_src/bushveld-gravity.py
@@ -5,12 +5,12 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 """
-Observed and preprocessed gravity data over Bushveld, Southern Africa
----------------------------------------------------------------------
+Gravity ground-based data over the Bushveld Complex, Southern Africa
+--------------------------------------------------------------------
 
 This dataset contains ground gravity observations over the area that comprises
 the Bushveld Igenous Complex in Southern Africa, including preprocessed gravity
-fields such as the **gravity disturbance** and the **bouguer gravity
+fields such as the **gravity disturbance** and the **Bouguer gravity
 disturbance** (topography-free gravity disturbance). In addition, the dataset
 contains the heights of the observation points referenced on the WGS84
 reference ellipsoid and over the mean sea-level (what can be considered to be
@@ -43,14 +43,15 @@ data
 fig = pygmt.Figure()
 fig.basemap(
     region=[
-        data.longitude.min() - 0.5,
-        data.longitude.max() + 0.5,
-        data.latitude.min() - 0.5,
-        data.latitude.max() + 0.5,
+        data.longitude.min(),
+        data.longitude.max(),
+        data.latitude.min(),
+        data.latitude.max(),
     ],
     projection="M15c",
     frame=True,
 )
+fig.coast(land="#444444")
 scale = np.max(np.abs(data.gravity_disturbance_mgal))
 pygmt.makecpt(
     cmap="polar",

--- a/doc/gallery_src/bushveld-gravity.py
+++ b/doc/gallery_src/bushveld-gravity.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2021 The Ensaio Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Observed and preprocessed gravity data over Bushveld, Southern Africa
+---------------------------------------------------------------------
+
+This dataset contains ground gravity observations over the area that comprises
+the Bushveld Igenous Complex in Southern Africa, including preprocessed gravity
+fields such as the **gravity disturbance** and the **bouguer gravity
+disturbance** (topography-free gravity disturbance). In addition, the dataset
+contains the heights of the observation points referenced on the WGS84
+reference ellipsoid and over the mean sea-level (what can be considered to be
+the geoid). This dataset was built upon a portion of the Southern Africa
+gravity compilation available through NOAA NCEI.
+
+**Original source:**
+* gravity: `NOAA NCEI <https://www.ngdc.noaa.gov/mgg/gravity/>`__
+* topography: `ETOPO1 <https://doi.org/10.7289/V5C8276M>`__
+
+"""
+import pandas as pd
+import numpy as np
+import pygmt
+
+import ensaio
+
+###############################################################################
+# Download and cache the data and return the path to it on disk
+fname = ensaio.fetch_bushveld_gravity(version=1)
+print(fname)
+
+###############################################################################
+# Load the CSV formatted data with pandas
+data = pd.read_csv(fname)
+data
+
+###############################################################################
+# Make a PyGMT map with the data points colored by the gravity data.
+fig = pygmt.Figure()
+fig.basemap(
+    region=[
+        data.longitude.min() - 0.5,
+        data.longitude.max() + 0.5,
+        data.latitude.min() - 0.5,
+        data.latitude.max() + 0.5,
+    ],
+    projection="M15c",
+    frame=True,
+)
+scale = np.max(np.abs(data.gravity_disturbance_mgal))
+pygmt.makecpt(
+    cmap="polar",
+    series=[-scale, scale],
+)
+fig.plot(
+    x=data.longitude,
+    y=data.latitude,
+    color=data.gravity_disturbance_mgal,
+    cmap=True,
+    style="c0.1c",
+)
+fig.colorbar(frame='af+l"gravity disturbance [mGal]"')
+fig.show()

--- a/doc/gallery_src/bushveld-gravity.py
+++ b/doc/gallery_src/bushveld-gravity.py
@@ -22,8 +22,8 @@ gravity compilation available through NOAA NCEI.
 * topography: `ETOPO1 <https://doi.org/10.7289/V5C8276M>`__
 
 """
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pygmt
 
 import ensaio

--- a/ensaio/__init__.py
+++ b/ensaio/__init__.py
@@ -9,6 +9,7 @@ from ._fetchers import (
     fetch_alps_gps,
     fetch_britain_magnetic,
     fetch_british_columbia_lidar,
+    fetch_bushveld_gravity,
     fetch_caribbean_bathymetry,
     fetch_earth_geoid,
     fetch_earth_gravity,

--- a/ensaio/_fetchers.py
+++ b/ensaio/_fetchers.py
@@ -346,7 +346,7 @@ def fetch_british_columbia_lidar(version):
 
 def fetch_bushveld_gravity(version):
     """
-    Observed and preprocessed gravity data over Bushveld, Southern Africa
+    Gravity ground-based data over the Bushveld Complex, Southern Africa
 
     This dataset contains ground gravity observations over the area that
     comprises the Bushveld Igenous Complex in Southern Africa, including

--- a/ensaio/_fetchers.py
+++ b/ensaio/_fetchers.py
@@ -34,6 +34,13 @@ REGISTRY = {
             "url": "https://github.com/fatiando-data/british-columbia-lidar/releases/download/v1",
         },
     },
+    "bushveld-gravity.csv.xz": {
+        "v1": {
+            "hash": "md5:368284cc210c6bbe256e9e49e892f262",
+            "doi": "doi:10.5281/zenodo.6511942",
+            "url": "https://github.com/fatiando-data/bushveld-gravity/releases/download/v1",
+        },
+    },
     "caribbean-bathymetry.csv.xz": {
         "v1": {
             "hash": "md5:a7332aa6e69c77d49d7fb54b764caa82",
@@ -334,6 +341,53 @@ def fetch_british_columbia_lidar(version):
     """
     _check_versions(version, allowed={1}, name="British Columbia lidar")
     fname = "british-columbia-lidar.csv.xz"
+    return Path(_repository(fname, version).fetch(fname))
+
+
+def fetch_bushveld_gravity(version):
+    """
+    Observed and preprocessed gravity data over Bushveld, Southern Africa
+
+    This dataset contains ground gravity observations over the area that
+    comprises the Bushveld Igenous Complex in Southern Africa, including
+    preprocessed gravity fields such as the **gravity disturbance** and the
+    **bouguer gravity disturbance** (topography-free gravity disturbance). In
+    addition, the dataset contains the heights of the observation points
+    referenced on the WGS84 reference ellipsoid and over the mean sea-level
+    (what can be considered to be the geoid). This dataset was built upon
+    a portion of the Southern Africa gravity compilation available through
+    `NOAA NCEI <https://www.ngdc.noaa.gov/mgg/gravity/>`__.
+
+    **Format:** CSV with xz (lzma) compression.
+
+    **Load with:** :func:`pandas.read_csv`
+
+    **Original source:** `NOAA NCEI <https://www.ngdc.noaa.gov/mgg/gravity/>`__
+    (gravity) and `ETOPO1 <https://doi.org/10.7289/V5C8276M>`__ (topography)
+
+    **Original license:** `public domain
+    <https://ngdc.noaa.gov/ngdcinfo/privacy.html>`__ (gravity) and `public
+    domain <https://ngdc.noaa.gov/mgg/global/dem_faq.html#sec-2.4>`__
+    (topography)
+
+    **Versions:**
+
+    * `1
+      <https://github.com/fatiando-data/bushveld-gravity/releases/tag/v1>`_
+      (doi:`10.5281/zenodo.6511942 <https://doi.org/10.5281/zenodo.6511942>`__)
+
+    Parameters
+    ----------
+    version : int
+        The data version to fetch. See the available versions above.
+
+    Returns
+    -------
+    fname : :class:`pathlib.Path`
+        Path to the downloaded file on disk.
+    """
+    _check_versions(version, allowed={1}, name="Bushveld gravity data")
+    fname = "bushveld-gravity.csv.xz"
     return Path(_repository(fname, version).fetch(fname))
 
 


### PR DESCRIPTION
**Description**
Add a new function for fetching and caching a CSV file containing preprocessed
gravity data over Bushveld, Souther Africa. The observed gravity was cropped
from the Southern Africa gravity dataset. This new dataset includes observation
heights referenced to the ellipsoid, a precomputed gravity disturbance and
a topography-free gravity disturbance.

