### PR TITLE
Add the Lightning Creek magnetic anomaly grid

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -17,6 +17,7 @@ List of functions and classes (API)
     ensaio.fetch_earth_geoid
     ensaio.fetch_earth_gravity
     ensaio.fetch_earth_topography
+    ensaio.fetch_lightning_creek_magnetic
     ensaio.fetch_osborne_magnetic
     ensaio.fetch_sierra_negra_topography
     ensaio.fetch_southern_africa_gravity

--- a/doc/gallery_src/lightning-creek-magnetic.py
+++ b/doc/gallery_src/lightning-creek-magnetic.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 The Ensaio Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Magnetic anomaly grid of the Lightning Creek Sill Complex, Australia
+--------------------------------------------------------------------
+
+This is a section of an airborne survey acquired in 1990 by the Queensland
+Government, Australia. The grid has 50 m resolution (UTM coordinates) and
+is at a uniform orthometric height of 500 m.
+
+**Original source:**
+`Geophysical Acquisition & Processing Section 2019. MIM Data from Mt Isa
+Inlier, QLD (P1029), magnetic line data, AWAGS levelled. Geoscience Australia,
+Canberra <http://pid.geoscience.gov.au/dataset/ga/142419>`__
+
+"""
+import pygmt
+import xarray as xr
+
+import ensaio
+
+###############################################################################
+# Download and cache the data and return the path to it on disk
+fname = ensaio.fetch_lightning_creek_magnetic(version=1)
+print(fname)
+
+###############################################################################
+# Load the netCDF grid with xarray
+data = xr.load_dataarray(fname)
+data
+
+###############################################################################
+# Make a PyGMT pseudo-color map of the total field magnetic anomaly.
+fig = pygmt.Figure()
+scale = 2500
+pygmt.makecpt(cmap="polar+h", series=[-scale, scale], background=True)
+fig.grdimage(
+    grid=data,
+    cmap=True,
+    shading="+a45+nt0.1",
+    projection="X15c/17c",
+    frame="af",
+)
+fig.colorbar(
+    frame='af+l"total field magnetic anomaly [nT]"',
+    position="JBC+h+o0/1c+e",
+)
+fig.show()
+
+###############################################################################
+# The anomaly at the top right is the  Lightning Creek sill complex.

--- a/ensaio/__init__.py
+++ b/ensaio/__init__.py
@@ -14,6 +14,7 @@ from ._fetchers import (
     fetch_earth_geoid,
     fetch_earth_gravity,
     fetch_earth_topography,
+    fetch_lightning_creek_magnetic,
     fetch_osborne_magnetic,
     fetch_sierra_negra_topography,
     fetch_southern_africa_gravity,

--- a/ensaio/_fetchers.py
+++ b/ensaio/_fetchers.py
@@ -69,6 +69,13 @@ REGISTRY = {
             "url": "https://github.com/fatiando-data/earth-topography-10arcmin/releases/download/v1",
         },
     },
+    "lightning-creek-magnetic-grid.nc": {
+        "v1": {
+            "hash": "md5:4b19c2eabe75865183964983861cbf68",
+            "doi": "doi:10.5281/zenodo.7079711",
+            "url": "https://github.com/fatiando-data/lightning-creek-magnetic-grid/releases/download/v1",
+        },
+    },
     "osborne-magnetic.csv.xz": {
         "v1": {
             "hash": "md5:b26777bdde2f1ecb97dda655c8b1cf71",
@@ -573,6 +580,49 @@ def fetch_earth_topography(version):
     """
     _check_versions(version, allowed={1}, name="Earth topography grid")
     fname = "earth-topography-10arcmin.nc"
+    return Path(_repository(fname, version).fetch(fname))
+
+
+def fetch_lightning_creek_magnetic(version):
+    """
+    Magnetic anomaly grid of the Lightning Creek Sill Complex, Australia
+
+    This is a section of a survey acquired in 1990 by the Queensland
+    Government, Australia. The grid has 50 m resolution (UTM coordinates) and
+    is at a uniform orthometric height of 500 m. Total field anomalies are in
+    nT.
+
+    **Format:** netCDF4 with zlib compression
+
+    **Load with:** :func:`xarray.load_dataarray` (requires the `netcdf4
+    <https://github.com/Unidata/netcdf4-python>`__ library)
+
+    **Original source:** `Geophysical Acquisition & Processing Section 2019.
+    MIM Data from Mt Isa Inlier, QLD (P1029), magnetic line data, AWAGS
+    levelled. Geoscience Australia, Canberra
+    <http://pid.geoscience.gov.au/dataset/ga/142419>`__
+
+    **Original license:** CC-BY
+
+    **Versions:**
+
+    * `1
+      <https://github.com/fatiando-data/lightning-creek-magnetic-grid/releases/tag/v1>`_
+      (doi:`10.5281/zenodo.7079711 <https://doi.org/10.5281/zenodo.7079711>`__)
+
+    Parameters
+    ----------
+    version : int
+        The data version to fetch. See the available versions above.
+
+    Returns
+    -------
+    fname : :class:`pathlib.Path`
+        Path to the downloaded file on disk.
+
+    """
+    _check_versions(version, allowed={1}, name="Lightning Creek magnetic")
+    fname = "lightning-creek-magnetic-grid.nc"
     return Path(_repository(fname, version).fetch(fname))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ exclude =
     .git,
     __pycache__,
     .ipynb_checkpoints,
+    doc/_build,
 per-file-ignores =
     # disable unused-imports errors on __init__.py
     __init__.py: F401


### PR DESCRIPTION
A gridded version of a section of our Osborne mine dataset. The grid is at uniform height and will be great for examples involving FFTs and other things that require grids.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
