### PR TITLE
Simplify the CI matrix for the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,13 @@ jobs:
         python:
           - "3.6"
           - "3.10"
-        dependencies:
-          - latest
-          - oldest
         cached:
           - true
         include:
+          - python: "3.6"
+            dependencies: oldest
+          - python: "3.10"
+            dependencies: latest
           - os: ubuntu
             python: "3.10"
             dependencies: latest


### PR DESCRIPTION
Instead of testing latest and oldest versions of dependencies in both 3.6 and 3.10, test only the latest with 3.10 and oldest with 3.6. Covers the expected behaviour and generates fewer jobs to run.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
