### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -45,7 +45,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -45,7 +45,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
 
@@ -47,7 +47,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,12 +44,12 @@ jobs:
           - macos
           - windows
         python:
-          - "3.6"
+          - "3.7"
           - "3.10"
         cached:
           - true
         include:
-          - python: "3.6"
+          - python: "3.7"
             dependencies: oldest
           - python: "3.10"
             dependencies: latest

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -53,7 +53,5 @@ following releases to ensure compatibility:
     * - **Python version**
       - **Last compatible release**
     * - 3.6
-      - 1.0.0
-    * - 3.7
-      - 1.X.0 (planned for late 2022)
+      - 0.4.0
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -39,7 +39,7 @@ There are different ways to install Ensaio:
 Which Python?
 -------------
 
-You'll need **Python >= 3.6** (see :ref:`python-versions` for information on
+You'll need **Python >= 3.7** (see :ref:`python-versions` for information on
 Python version compatibility).
 
 We recommend using the

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
     Topic :: Scientific/Engineering
     Topic :: Software Development :: Libraries
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ project_urls =
 [options]
 zip_safe = True
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     pooch>=1.5.0,<2.0.0
 


### PR DESCRIPTION
Actions is failing on Ubuntu complaining that Python 3.6 is no longer available. Update the Python action to v4 and drop support for Python 3.6 since we could have done this a while ago.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
