### PR TITLE
Fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
           # Fail the job so we know coverage isn't being updated. Otherwise it

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,11 +161,10 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
-          # Don't mark the job as failed if the upload fails for some reason.
-          # It does sometimes but shouldn't be the reason for running
-          # everything again unless something else is broken.
-          fail_ci_if_error: false
+          # Fail the job so we know coverage isn't being updated. Otherwise it
+          # can silently drop and we won't know.
+          fail_ci_if_error: true

--- a/ensaio/tests/test_fetchers.py
+++ b/ensaio/tests/test_fetchers.py
@@ -58,7 +58,7 @@ def test_data_source_from_github(use_github):
     "Check that GitHub is used as a data source when the env variable is set"
     backup = None
     try:
-        backup = os.environ.get("ENSAIO_DATA_FROM_GITHUB", None)
+        backup = os.environ.get("ENSAIO_DATA_FROM_GITHUB")
         os.environ["ENSAIO_DATA_FROM_GITHUB"] = use_github
         repo = _fetchers._repository(fname="alps-gps-velocity.csv.xz", version=1)
         if use_github == "True":


### PR DESCRIPTION
Let the CI job fail if the codecov upload fails. Otherwise it could stop and we wouldn't know.


