### PR TITLE
Remove the schedule CI run of the tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,6 @@ on:
   release:
     types:
       - published
-  schedule:
-    # Run every Monday at 12:00 UTC
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '00 12 * * 1'
 
 # Use bash by default in all jobs
 defaults:


### PR DESCRIPTION
We had it set to run every week but the project changes very infrequently which was causing GitHub to disable the Action entirely. Remove it since it's not really necessary.


