### PR TITLE
Add testing and support for Python 3.11

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.10"
+      PYTHON: "3.11"
 
     steps:
       # Cancel any previous run of the test job

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,20 +39,21 @@ jobs:
           - ubuntu
           - macos
           - windows
-        python:
-          - "3.7"
-          - "3.10"
         cached:
           - true
+        dependencies:
+          - oldest
+          - latest
         include:
-          - python: "3.7"
-            dependencies: oldest
-          - python: "3.10"
-            dependencies: latest
+          - dependencies: oldest
+            python: "3.9"
+          - dependencies: latest
+            python: "3.11"
           - os: ubuntu
-            python: "3.10"
+            python: "3.11"
             dependencies: latest
             cached: false
+
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.10
+  - python==3.11
   - pip
   - make
   # Run

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 url = https://github.com/fatiando/ensaio
 project_urls =
     Documentation = https://www.fatiando.org/ensaio


### PR DESCRIPTION
Simplify the test matrix as well to only run the latest dependencies on latest python and oldest on oldest Python.