### PR TITLE
Configure PyPI deployment using Trusted Publishers

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -68,7 +68,7 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        if: success() && github.event_name != 'pull_request'
+        #if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pypi-${{ github.sha }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -78,7 +78,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    #if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    environment: pypi
+    permissions:
+      # This permission allows trusted publishing to PyPI (without an API token)
+      id-token: write
 
     steps:
       - name: Checkout
@@ -97,11 +101,9 @@ jobs:
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        if: success() && github.event_name == 'push'
+        #if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           # Allow existing releases on test PyPI without errors.
           # NOT TO BE USED in PyPI!
@@ -111,6 +113,3 @@ jobs:
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.8.12
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -68,7 +68,7 @@ jobs:
       # Store the archives as a build artifact so we can deploy them later
       - name: Upload archives as artifacts
         # Only if not a pull request
-        #if: success() && github.event_name != 'pull_request'
+        if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: pypi-${{ github.sha }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     # Only publish from the origin repository, not forks
-    #if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
+    if: github.repository_owner == 'fatiando' && github.event_name != 'pull_request'
     environment: pypi
     permissions:
       # This permission allows trusted publishing to PyPI (without an API token)
@@ -101,7 +101,7 @@ jobs:
 
       - name: Publish to Test PyPI
         # Only publish to TestPyPI when a PR is merged (pushed to main)
-        #if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@v1.8.12
         with:
           repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Replace the API tokens currently used. This is safer and simplifies our setup.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Related to fatiando/community#141