### PR TITLE
Drop support for Python 3.7 + 3.8, add for 3.13

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -85,6 +85,14 @@ jobs:
           echo "Collected dependencies:"
           cat requirements-full.txt
 
+      - name: Rename conda-forge packages
+        run: |
+          echo "Rename conda-forge packages in requirements-full.txt"
+          # Replace "build" for "python-build"
+          sed -s --in-place 's/^build$/python-build/' requirements-full.txt
+          echo "Renamed dependencies:"
+          cat requirements-full.txt
+
       - name: Install requirements
         run: conda install --quiet --file requirements-full.txt python==$PYTHON
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       REQUIREMENTS: env/requirements-docs.txt env/requirements-build.txt
-      PYTHON: "3.11"
+      PYTHON: "3.13"
 
     steps:
       # Cancel any previous run of the test job

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-build.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install requirements
         run: python -m pip install -r env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,9 @@ jobs:
           - dependencies: oldest
             python: "3.9"
           - dependencies: latest
-            python: "3.11"
+            python: "3.13"
           - os: ubuntu
-            python: "3.11"
+            python: "3.13"
             dependencies: latest
             cached: false
 

--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -54,4 +54,7 @@ following releases to ensure compatibility:
       - **Last compatible release**
     * - 3.6
       - 0.4.0
-
+    * - 3.7
+      - 0.6.0
+    * - 3.8
+      - 0.6.0

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -5,50 +5,43 @@ Installing
 
 There are different ways to install Ensaio:
 
-.. tabbed:: pip
+.. tab-set::
 
-    Using the `pip <https://pypi.org/project/pip/>`__ package manager:
+    .. tab-item:: pip
 
-    .. code:: bash
+        Using the `pip package manager <https://pypi.org/project/pip/>`__:
 
-        python -m pip install ensaio
+        .. code:: bash
 
-.. tabbed:: conda
+            pip install ensaio
 
-    Using the `conda <https://conda.io/>`__ package manager that comes with the
-    Anaconda/Miniconda distribution:
+    .. tab-item:: conda/mamba
 
-    .. code:: bash
+        Using the `conda package manager <https://conda.io/>`__ (or ``mamba``)
+        that comes with the Anaconda, Miniconda, or Miniforge distributions:
 
-        conda install ensaio --channel conda-forge
+        .. code:: bash
 
-.. tabbed:: Development version
+            conda install ensaio --channel conda-forge
 
-    Using ``pip`` to install the latest **unreleased** version from GitHub
-    (**not recommended** in most situations):
+    .. tab-item:: Development version
 
-    .. code:: bash
+        You can use ``pip`` to install the latest **unreleased** version from
+        GitHub (**not recommended** in most situations):
 
-        python -m pip install --upgrade git+https://github.com/fatiando/ensaio
+        .. code:: bash
+
+            python -m pip install --upgrade git+https://github.com/fatiando/ensaio
 
 .. note::
 
     The commands above should be executed in a terminal. On Windows, use the
     ``cmd.exe`` or the "Anaconda Prompt" app if you're using Anaconda.
 
-Which Python?
--------------
+.. admonition:: Which Python?
+    :class: tip
 
-You'll need **Python >= 3.7** (see :ref:`python-versions` for information on
-Python version compatibility).
-
-We recommend using the
-`Anaconda <https://www.anaconda.com/download>`__
-or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
-Python distributions to ensure you have all dependencies installed and the
-``conda`` package manager available.
-Installing Anaconda does not require administrative rights to your computer and
-doesn't interfere with any other Python installations in your system.
+    See :ref:`python-versions` for a list of  supported Python versions.
 
 .. _dependencies:
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.11
+  - python==3.13
   - pip
   - make
   # Run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "pooch>=1.5.0,<2.0.0",
 ]


### PR DESCRIPTION
Both older versions are out of the range of support and Python 3.13 has been released recently.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:** Fixes #75 
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
