### PR TITLE
Make the README banner the h1 element and add citation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-<img src="https://github.com/fatiando/ensaio/raw/main/doc/_static/readme-banner.png" alt="Ensaio">
+<h1><img src="https://github.com/fatiando/ensaio/raw/main/doc/_static/readme-banner.png" alt="Ensaio"></h1>
 
-<h2 align="center">Practice datasets to probe your code</h2>
+<p align="center"><strong>Practice datasets to probe your code</strong></p>
 
 <p align="center">
 <a href="https://www.fatiando.org/ensaio"><strong>Documentation</strong> (latest)</a> •
-<a href="https://www.fatiando.org/ensaio/dev"><strong>Documentation</strong> (main branch)</a> •
-<a href="https://github.com/fatiando/ensaio/blob/main/CONTRIBUTING.md"><strong>Contributing</strong></a> •
+<a href="https://www.fatiando.org/ensaio/dev"><strong>Documentation</strong> (development)</a> •
+<a href="https://github.com/fatiando/ensaio/blob/main/CONTRIBUTING.md"><strong>Contribute</strong></a> •
 <a href="https://www.fatiando.org/contact/"><strong>Contact</strong></a> •
-<a href="https://github.com/orgs/fatiando/discussions"><strong>Ask a question</strong></a>
+<a href="https://github.com/orgs/fatiando/discussions"><strong>Ask a question</strong></a> •
+<a href="https://www.fatiando.org/ensaio/latest/citing.html"><strong>Cite</strong></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <a href="https://github.com/fatiando/ensaio/blob/main/CONTRIBUTING.md"><strong>Contribute</strong></a> •
 <a href="https://www.fatiando.org/contact/"><strong>Contact</strong></a> •
 <a href="https://github.com/orgs/fatiando/discussions"><strong>Ask a question</strong></a> •
-<a href="https://www.fatiando.org/ensaio/latest/citing.html"><strong>Cite</strong></a>
+<a href="https://www.fatiando.org/ensaio/dev/citing.html"><strong>Cite</strong></a>
 </p>
 
 <p align="center">

--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -1,0 +1,11 @@
+.. _citing:
+
+Citing Ensaio
+=============
+
+This is research software **made by scientists**. Citations help us justify the
+effort that goes into building and maintaining this project.
+
+If you used Ensaio in your research, please consider
+citing the latest Zenodo archive: https://doi.org/10.5281/zenodo.5784202
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -104,6 +104,7 @@ computer already.
     :maxdepth: 1
 
     api/index.rst
+    citing.rst
     compatibility.rst
     changes.rst
     versions.rst


### PR DESCRIPTION
The README should follow standard HTML heading progressions. Before, we skipped the h1 heading and went straight to h2. Make the banner the h1 heading with an alt text. That means that the tag line shouldn't be an h2 as well but just a plain paragraph. We used the h2 for the font size but that's not ideal for accessibility. Also add a citation page to the docs and a link to it in the README to make it easier to find.