### PR TITLE
General improvements to install and version compatibility pages

### DIFF
--- a/doc/compatibility.rst
+++ b/doc/compatibility.rst
@@ -18,6 +18,16 @@ Ensaio uses `semantic versioning <https://semver.org/>`__ (i.e.,
 
 **We aim for Ensaio to be backwards compatible whenever possible and will make
 major releases sparingly and with ample warning.**
+We will add ``FutureWarning`` messages about deprecations ahead of making any
+breaking changes to give users a chance to upgrade.
+
+.. warning::
+
+    The above does not apply to versions < ``1.0.0``. All ``0.*`` versions may
+    deprecate, remove, or change functionality between releases. Proper
+    warnings may be raised, and any breaking changes will be marked as such in
+    the :ref:`changes`.
+
 
 Source data releases
 --------------------
@@ -39,11 +49,31 @@ Ensaio.
     See :ref:`developers` for more tips and tricks.
 
 
+.. _dependency-versions:
+
+Supported dependency versions
+-----------------------------
+
+Ensaio follows the recommendations in
+`NEP29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ for setting
+the minimum required version of our dependencies.
+In short, we support **all minor releases of our dependencies from the previous
+24 months** before an Ensaio release with a minimum of 2 minor releases.
+
+We follow this guidance conservatively and won't require newer versions if the
+older ones are still working without causing problems.
+Whenever support for a version is dropped, we will include a note in the
+:ref:`changes`.
+
+Exact version constraints on our dependencies can be found in the `pyproject.toml file <https://github.com/fatiando/ensaio/blob/main/pyproject.toml>`__.
+
+
 .. _python-versions:
 
 Python version compatibility
 ----------------------------
 
+Ensaio supports Python versions greater than the ones listed below.
 If you require support for older Python versions, please pin Ensaio to the
 following releases to ensure compatibility:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,22 +7,22 @@ There are different ways to install Ensaio:
 
 .. tab-set::
 
-    .. tab-item:: pip
-
-        Using the `pip package manager <https://pypi.org/project/pip/>`__:
-
-        .. code:: bash
-
-            pip install ensaio
-
     .. tab-item:: conda/mamba
 
-        Using the `conda package manager <https://conda.io/>`__ (or ``mamba``)
+        Using the `conda <https://conda.io/>`__ package manager (or ``mamba``)
         that comes with the Anaconda, Miniconda, or Miniforge distributions:
 
         .. code:: bash
 
             conda install ensaio --channel conda-forge
+
+    .. tab-item:: pip
+
+        Using the `pip <https://pypi.org/project/pip/>`__ package manager:
+
+        .. code:: bash
+
+            python -m pip install ensaio
 
     .. tab-item:: Development version
 
@@ -33,15 +33,26 @@ There are different ways to install Ensaio:
 
             python -m pip install --upgrade git+https://github.com/fatiando/ensaio
 
-.. note::
+.. tip::
 
     The commands above should be executed in a terminal. On Windows, use the
-    ``cmd.exe`` or the "Anaconda Prompt" app if you're using Anaconda.
+    ``cmd.exe`` or the "Anaconda Prompt" / "Miniforge Prompt" app if you're using
+    Anaconda / Miniforge.
 
 .. admonition:: Which Python?
     :class: tip
 
     See :ref:`python-versions` for a list of  supported Python versions.
+
+.. note::
+
+   We recommend using the
+   `Miniforge distribution <https://conda-forge.org/download/>`__
+   to ensure that you have the ``conda`` package manager available.
+   Installing Miniforge does not require administrative rights to your computer
+   and doesn't interfere with any other Python installations in your system.
+   It's also much smaller than the Anaconda distribution and is less likely to
+   break when installing new software.
 
 .. _dependencies:
 
@@ -54,6 +65,11 @@ Ensaio using ``conda`` or ``pip``.
 Required:
 
 * `Pooch <https://www.fatiando.org/pooch/>`__
+
+.. note::
+
+    See :ref:`dependency-versions` for our policy of oldest supported
+    versions of each dependency.
 
 Our examples use other packages to load and plot the data.
 If you wish to **run the examples in the documentation**, you will also have to


### PR DESCRIPTION
Add more links to other sections, including the version compatibility. Add statement about the minimum Python version required. Prioritize the miniforge install and recommendation. Add the dependency version policy and link to pyproject.toml.