### PR TITLE
Fix paths for GitHub Actions triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,8 +10,8 @@ name: documentation
 on:
   pull_request:
     paths:
-      - doc
-      - src
+      - doc/**
+      - src/**
       - pyproject.toml
       - env/requirements-build.txt
       - env/requirements-docs.txt

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,8 +10,8 @@ name: code-style
 on:
   pull_request:
     paths:
-      - src
-      - test
+      - src/**
+      - test/**
       - doc/conf.py
       - pyproject.toml
       - env/requirements-style.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ name: test
 on:
   pull_request:
     paths:
-      - src
-      - test
+      - src/**
+      - test/**
       - pyproject.toml
       - env/requirements-build.txt
       - env/requirements-test.txt


### PR DESCRIPTION
The triggers didn't include the `/**` when specifying folders so the workflows weren't being triggered properly.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:** Fixes #129. See also  https://github.com/fatiando/bordado/pull/127
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
